### PR TITLE
make Settings properties optional

### DIFF
--- a/src/pdftocairo.ts
+++ b/src/pdftocairo.ts
@@ -5,8 +5,8 @@ import {listFiles} from './helpers';
  * Cairo settings type
  */
 type Settings = {
-  root: string;
-  prefix: string;
+  root?: string;
+  prefix?: string;
   options?: Array<string>;
 };
 

--- a/src/pdftohtml.ts
+++ b/src/pdftohtml.ts
@@ -5,7 +5,7 @@ import {execute} from './execute';
  * HTML settings type
  */
 type Settings = {
-  root: string;
+  root?: string;
   options?: Array<string>;
 };
 

--- a/src/pdftoppm.ts
+++ b/src/pdftoppm.ts
@@ -5,8 +5,8 @@ import {listFiles} from './helpers';
  * PPM settings type
  */
 type Settings = {
-  root: string;
-  prefix: string;
+  root?: string;
+  prefix?: string;
   options?: Array<string>;
 };
 


### PR DESCRIPTION
All properties of Settings can be optional, because they are initialized with the values from defaultSettings